### PR TITLE
Fix/proxy conf with snap install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .venv
 .cache
 
+/.idea

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,7 +7,11 @@ ssm_service: '{%- if snap_available.stat.exists -%}
                 {%- else -%}
                     amazon-ssm-agent
                 {%- endif -%}'
-ssm_systemd_file: /etc/systemd/system/amazon-ssm-agent.service
+ssm_systemd_file: '{%- if snap_available.stat.exists -%}
+                    /etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service
+                {%- else -%}
+                    /etc/systemd/system/amazon-ssm-agent.service
+                {%- endif -%}'
 ssm_agent_bin: '{%- if snap_available.stat.exists -%}
                     /snap/amazon-ssm-agent/current/amazon-ssm-agent
                 {%- else -%}


### PR DESCRIPTION
I need to configure ssm agent proxy on ubuntu 2004 (agent installed with snap). It fails because agent proxy configuration task does not find service configuration file (`/etc/systemd/system/amazon-ssm-agent.service` instead of `/etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service`)